### PR TITLE
Fixed wrong path on pip3 install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ And install with ``pip``:
 
 ::
 
-    pip3 install ./kik-bot-unofficial-api
+    cd kik-bot-api-unofficial; pip3 install kik_unofficial
 
 Usage
 -----


### PR DESCRIPTION
Hello,

I have noticed that the documentation was misleading in a new installation of the bot.


Thanks