### PR TITLE
Device configuration overrides, intermediary captcha solving, separate logging

### DIFF
--- a/kik_unofficial/client.py
+++ b/kik_unofficial/client.py
@@ -23,7 +23,7 @@ HOST, PORT = "talk1110an.kik.com", 5223
 
 class KikClient:
     def __init__(self, callback: callbacks.KikClientCallback, kik_username=None, kik_password=None,
-                 kik_node=None, log_level=logging.INFO):
+                 kik_node=None, log_level=logging.INFO, device_id_override=None, andoid_id_override=None):
         """
         Initializes a connection to Kik servers.
         If you want to automatically login too, use the username and password parameters.
@@ -41,6 +41,8 @@ class KikClient:
         self.username = kik_username
         self.password = kik_password
         self.kik_node = kik_node
+        self.device_id_override = device_id_override
+        self.android_id_override = andoid_id_override
 
         self.callback = callback
 
@@ -80,7 +82,7 @@ class KikClient:
             # we have all required credentials, we can authenticate
             logging.info("[+] Establishing authenticated connection using kik node '{}'...".format(self.kik_node))
 
-            message = login.EstablishAuthenticatedSessionRequest(self.kik_node, self.username, self.password)
+            message = login.EstablishAuthenticatedSessionRequest(self.kik_node, self.username, self.password, self.device_id_override)
             self.initial_connection_payload = message.serialize()
         else:
             self.initial_connection_payload = '<k anon="">'.encode()
@@ -110,7 +112,7 @@ class KikClient:
         """
         self.username = username
         self.password = password
-        login_request = login.LoginRequest(username, password, captcha_result)
+        login_request = login.LoginRequest(username, password, captcha_result, self.device_id_override, self.android_id_override)
         logging.info("[+] Logging in with username '{}' and a given password..."
                      .format(username, '*' * len(password)))
         return self.send_xmpp_element(login_request)
@@ -121,7 +123,8 @@ class KikClient:
         """
         self.username = username
         self.password = password
-        register_message = sign_up.RegisterRequest(email, username, password, first_name, last_name, birthday, captcha_result)
+        register_message = sign_up.RegisterRequest(email, username, password, first_name, last_name, birthday, captcha_result,
+                                                   self.device_id_override, self.android_id_override)
         logging.info("[+] Sending sign up request (name: {} {}, email: {})...".format(first_name, last_name, email))
         return self.send_xmpp_element(register_message)
 

--- a/kik_unofficial/client.py
+++ b/kik_unofficial/client.py
@@ -1,22 +1,22 @@
-import sys
-import time
 import asyncio
 import logging
+import sys
+import time
 from asyncio import Transport, Protocol
 from threading import Thread
 from typing import Union, List, Tuple
-from bs4 import BeautifulSoup
 
-import kik_unofficial.datatypes.xmpp.chatting as chatting
-import kik_unofficial.datatypes.xmpp.group_adminship as group_adminship
-import kik_unofficial.datatypes.xmpp.roster as roster
-import kik_unofficial.datatypes.xmpp.sign_up as sign_up
-import kik_unofficial.datatypes.xmpp.login as login
-import kik_unofficial.xmlns_handlers as xmlns_handlers
 import kik_unofficial.callbacks as callbacks
 import kik_unofficial.datatypes.exceptions as exceptions
-from kik_unofficial.http import profilepics
+import kik_unofficial.datatypes.xmpp.chatting as chatting
+import kik_unofficial.datatypes.xmpp.group_adminship as group_adminship
+import kik_unofficial.datatypes.xmpp.login as login
+import kik_unofficial.datatypes.xmpp.roster as roster
+import kik_unofficial.datatypes.xmpp.sign_up as sign_up
+import kik_unofficial.xmlns_handlers as xmlns_handlers
+from bs4 import BeautifulSoup
 from kik_unofficial.datatypes.xmpp.base_elements import XMPPElement
+from kik_unofficial.http import profilepics
 
 HOST, PORT = "talk1110an.kik.com", 5223
 log = logging.getLogger('kik_unofficial')
@@ -227,6 +227,9 @@ class KikClient:
 
     def set_background_picture(self, filename):
         profilepics.set_background_picture(filename, self.kik_node + '@talk.kik.com', self.username, self.password)
+
+    def send_captcha_result(self, captcha_result):
+        return self.send_xmpp_element(login.CaptchaSolveRequest(captcha_result))
 
     def disconnect(self):
         log.info("[!] Disconnecting.")

--- a/kik_unofficial/client.py
+++ b/kik_unofficial/client.py
@@ -228,8 +228,8 @@ class KikClient:
     def set_background_picture(self, filename):
         profilepics.set_background_picture(filename, self.kik_node + '@talk.kik.com', self.username, self.password)
 
-    def send_captcha_result(self, captcha_result):
-        return self.send_xmpp_element(login.CaptchaSolveRequest(captcha_result))
+    def send_captcha_result(self, stc_id, captcha_result):
+        return self.send_xmpp_element(login.CaptchaSolveRequest(stc_id, captcha_result))
 
     def disconnect(self):
         log.info("[!] Disconnecting.")

--- a/kik_unofficial/datatypes/xmpp/login.py
+++ b/kik_unofficial/datatypes/xmpp/login.py
@@ -17,11 +17,13 @@ class LoginRequest(XMPPElement):
     """
     Represents a Kik Login request.
     """
-    def __init__(self, username, password, captcha_result=None):
+    def __init__(self, username, password, captcha_result=None, device_id_override=None, android_id_override=None):
         super().__init__()
         self.username = username
         self.password = password
         self.captcha_result = captcha_result
+        self.device_id_override = device_id_override
+        self.android_id_override = android_id_override
 
     def serialize(self) -> bytes:
         password_key = CryptographicUtils.key_from_password(self.username, self.password)
@@ -46,8 +48,8 @@ class LoginRequest(XMPPElement):
                 '<model>Samsung Galaxy S5 - 4.4.4 - API 19 - 1080x1920</model>'
                 '{}'
                 '</query>'
-                '</iq>').format(self.message_id, self.username, password_key,
-                                device_id, kik_version, android_id, captcha)
+                '</iq>').format(self.message_id, self.username, password_key, self.device_id_override if self.device_id_override else device_id,
+                                kik_version, self.android_id_override if self.android_id_override else android_id, captcha)
         return data.encode()
 
 
@@ -69,15 +71,16 @@ class EstablishAuthenticatedSessionRequest(XMPPElement):
     a request sent on the begging of the connection to establish
     an authenticated session. That is, on the behalf of a specific kik user, with his credentials.
     """
-    def __init__(self, node, username, password):
+    def __init__(self, node, username, password, device_id_override=None):
         super().__init__()
         self.node = node
         self.username = username
         self.password = password
+        self.device_id_override = device_id_override
 
     def serialize(self):
         jid = self.node + "@talk.kik.com"
-        jid_with_resource = jid + "/CAN" + device_id
+        jid_with_resource = jid + "/CAN" + self.device_id_override if self.device_id_override else device_id
         timestamp = "1496333389122"
         sid = CryptographicUtils.make_kik_uuid()
 

--- a/kik_unofficial/datatypes/xmpp/login.py
+++ b/kik_unofficial/datatypes/xmpp/login.py
@@ -123,6 +123,7 @@ class CaptchaElement:
     def __init__(self, data: BeautifulSoup):
         self.type = data.stp['type']
         self.captcha_url = data.stp.text + "&callback_url=https://kik.com/captcha-url"
+        self.stc_id = data['id']
 
 
 class CaptchaSolveRequest(XMPPElement):
@@ -130,14 +131,15 @@ class CaptchaSolveRequest(XMPPElement):
     Response to the 'stc' element. Given the result of the captcha, the connection will resume.
     """
 
-    def __init__(self, captcha_result: str):
+    def __init__(self, stc_id: str, captcha_result: str):
         super().__init__()
         self.captcha_result = captcha_result
+        self.stc_id = stc_id
 
     def serialize(self) -> bytes:
         data = (
             '<stc id="{}">'
             '<sts>{}</sts>'
             '</stc>'
-        ).format(self.message_id, self.captcha_result)
+        ).format(self.stc_id, self.captcha_result)
         return data.encode()

--- a/kik_unofficial/datatypes/xmpp/login.py
+++ b/kik_unofficial/datatypes/xmpp/login.py
@@ -1,13 +1,13 @@
-import hashlib
-import hmac
-import rsa
 import base64
 import binascii
-from bs4 import BeautifulSoup
+import hashlib
+import hmac
 
+import rsa
+from bs4 import BeautifulSoup
 from kik_unofficial.datatypes.xmpp.base_elements import XMPPElement
-from kik_unofficial.utilities.cryptographics import CryptographicUtils
 from kik_unofficial.device_configuration import device_id, kik_version_info, android_id
+from kik_unofficial.utilities.cryptographics import CryptographicUtils
 
 captcha_element = '<challenge><response>{}</response></challenge>'
 kik_version = kik_version_info["kik_version"]
@@ -17,6 +17,7 @@ class LoginRequest(XMPPElement):
     """
     Represents a Kik Login request.
     """
+
     def __init__(self, username, password, captcha_result=None, device_id_override=None, android_id_override=None):
         super().__init__()
         self.username = username
@@ -57,6 +58,7 @@ class LoginResponse:
     """
     Represents a Kik Login response.
     """
+
     def __init__(self, data: BeautifulSoup):
         self.kik_node = data.query.node.text
         self.email = data.query.email.text
@@ -71,6 +73,7 @@ class EstablishAuthenticatedSessionRequest(XMPPElement):
     a request sent on the begging of the connection to establish
     an authenticated session. That is, on the behalf of a specific kik user, with his credentials.
     """
+
     def __init__(self, node, username, password, device_id_override=None):
         super().__init__()
         self.node = node
@@ -115,9 +118,26 @@ class CaptchaElement:
     """
     The 'stc' element occurs when Kik requires a captcha to be filled in, it's followed up by a 'hold' element after which the connection is
     paused.
-
-    TODO: Find out how to resume the connection.
     """
+
     def __init__(self, data: BeautifulSoup):
         self.type = data.stp['type']
         self.captcha_url = data.stp.text + "&callback_url=https://kik.com/captcha-url"
+
+
+class CaptchaSolveRequest(XMPPElement):
+    """
+    Response to the 'stc' element. Given the result of the captcha, the connection will resume.
+    """
+
+    def __init__(self, captcha_result: str):
+        super().__init__()
+        self.captcha_result = captcha_result
+
+    def serialize(self) -> bytes:
+        data = (
+            '<stc id="{}">'
+            '<sts>{}</sts>'
+            '</stc>'
+        ).format(self.message_id, self.captcha_result)
+        return data.encode()

--- a/kik_unofficial/datatypes/xmpp/login.py
+++ b/kik_unofficial/datatypes/xmpp/login.py
@@ -80,7 +80,7 @@ class EstablishAuthenticatedSessionRequest(XMPPElement):
 
     def serialize(self):
         jid = self.node + "@talk.kik.com"
-        jid_with_resource = jid + "/CAN" + self.device_id_override if self.device_id_override else device_id
+        jid_with_resource = jid + "/CAN" + (self.device_id_override if self.device_id_override else device_id)
         timestamp = "1496333389122"
         sid = CryptographicUtils.make_kik_uuid()
 

--- a/kik_unofficial/datatypes/xmpp/sign_up.py
+++ b/kik_unofficial/datatypes/xmpp/sign_up.py
@@ -1,8 +1,7 @@
 from bs4 import BeautifulSoup
-
 from kik_unofficial.datatypes.xmpp.base_elements import XMPPElement, XMPPResponse
-from kik_unofficial.utilities.cryptographics import CryptographicUtils
 from kik_unofficial.device_configuration import device_id, android_id, kik_version_info
+from kik_unofficial.utilities.cryptographics import CryptographicUtils
 
 captcha_element = '<challenge><response>{}</response></challenge>'
 
@@ -11,7 +10,9 @@ class RegisterRequest(XMPPElement):
     """
     Represents a Kik sign up request
     """
-    def __init__(self, email, username, password, first_name, last_name, birthday="1974-11-20", captcha_result=None):
+
+    def __init__(self, email, username, password, first_name, last_name, birthday="1974-11-20", captcha_result=None, device_id_override=None,
+                 android_id_override=None):
         super().__init__()
         self.email = email
         self.username = username
@@ -20,6 +21,8 @@ class RegisterRequest(XMPPElement):
         self.last_name = last_name
         self.birthday = birthday
         self.captcha_result = captcha_result
+        self.device_id_override = device_id_override
+        self.android_id_override = android_id_override
 
     def serialize(self):
         passkey_e = CryptographicUtils.key_from_password(self.email, self.password)
@@ -48,9 +51,9 @@ class RegisterRequest(XMPPElement):
                 '<brand>google</brand>'
                 '<android-id>{}</android-id>'
                 '</query>'
-                '</iq>').format(self.message_id, self.email, passkey_e, passkey_u, device_id, self.username,
-                                self.first_name, self.last_name, self.birthday, captcha,
-                                kik_version_info["kik_version"], android_id)
+                '</iq>').format(self.message_id, self.email, passkey_e, passkey_u, self.device_id_override if self.device_id_override else device_id,
+                                self.username, self.first_name, self.last_name, self.birthday, captcha, kik_version_info["kik_version"],
+                                self.android_id_override if self.android_id_override else android_id)
 
         return data.encode()
 

--- a/kik_unofficial/http/profilepics.py
+++ b/kik_unofficial/http/profilepics.py
@@ -6,7 +6,7 @@ import requests
 from kik_unofficial.datatypes.exceptions import KikApiException
 from kik_unofficial.utilities.cryptographics import CryptographicUtils
 
-logging = logging.getLogger()
+log = logging.getLogger('kik_unofficial')
 
 
 def set_profile_picture(file, jid, username, password):
@@ -34,7 +34,7 @@ def send(url, filename, jid, username, password):
 def picture_upload_thread(url, filename, headers):
     with open(filename, 'rb') as picture:
         picture_data = picture.read()
-    logging.debug('Uploading picture')
+    log.debug('Uploading picture')
     r = requests.post(url, data=picture_data, headers=headers)
     if r.status_code != 200:
         raise KikApiException(r.status_code)

--- a/kik_unofficial/http/profilepics.py
+++ b/kik_unofficial/http/profilepics.py
@@ -10,12 +10,12 @@ log = logging.getLogger('kik_unofficial')
 
 
 def set_profile_picture(file, jid, username, password):
-    url = 'http://profilepicsup.kik.com/profilepics'
+    url = 'https://profilepicsup.kik.com/profilepics'
     send(url, file, jid, username, password)
 
 
 def set_background_picture(file, jid, username, password):
-    url = 'http://profilepicsup.kik.com/profilepics?extension_type=BACKGROUND'
+    url = 'https://profilepicsup.kik.com/profilepics?extension_type=BACKGROUND'
     send(url, file, jid, username, password)
 
 

--- a/kik_unofficial/xmlns_handlers.py
+++ b/kik_unofficial/xmlns_handlers.py
@@ -88,7 +88,7 @@ class MessageHandler(XmlnsHandler):
                 self.callback.on_image_received(IncomingImageMessage(data))
             else:
                 # what else? GIFs?
-                logging.debug("[-] Received unknown chat message. contents: {}".format(str(data)))
+                log.debug("[-] Received unknown chat message. contents: {}".format(str(data)))
         elif data['type'] == 'receipt':
             if data.receipt['type'] == 'delivered':
                 self.callback.on_message_delivered(IncomingMessageDeliveredEvent(data))

--- a/kik_unofficial/xmlns_handlers.py
+++ b/kik_unofficial/xmlns_handlers.py
@@ -10,6 +10,8 @@ from kik_unofficial.datatypes.xmpp.roster import FetchRosterResponse, PeerInfoRe
 from kik_unofficial.datatypes.xmpp.sign_up import RegisterResponse, UsernameUniquenessResponse
 from kik_unofficial.datatypes.xmpp.login import LoginResponse
 
+log = logging.getLogger('kik_unofficial')
+
 
 class XmlnsHandler:
     def __init__(self, callback: KikClientCallback, api):
@@ -33,12 +35,12 @@ class RegisterHandler(XmlnsHandler):
             if data.find('email'):
                 # sign up
                 sign_up_error = SignUpError(data)
-                logging.info("[-] Register error: {}".format(sign_up_error))
+                log.info("[-] Register error: {}".format(sign_up_error))
                 self.callback.on_register_error(sign_up_error)
 
             else:
                 login_error = LoginError(data)
-                logging.info("[-] Login error: {}".format(login_error))
+                log.info("[-] Login error: {}".format(login_error))
                 self.callback.on_login_error(login_error)
 
         elif message_type == "result":
@@ -47,13 +49,13 @@ class RegisterHandler(XmlnsHandler):
             if data.find('email'):
                 # login successful
                 response = LoginResponse(data)
-                logging.info("[+] Logged in as {}".format(response.username))
+                log.info("[+] Logged in as {}".format(response.username))
                 self.callback.on_login_ended(response)
                 self.api._establish_authenticated_session(response.kik_node)
             else:
                 # sign up successful
                 response = RegisterResponse(data)
-                logging.info("[+] Registered.")
+                log.info("[+] Registered.")
                 self.callback.on_sign_up_ended(response)
                 self.api._establish_authenticated_session(response.kik_node)
 
@@ -79,7 +81,7 @@ class MessageHandler(XmlnsHandler):
             elif data.find('xiphias-mobileremote-call'):
                 # usually SafetyNet-related (?)
                 mobile_remote_call = data.find('xiphias-mobileremote-call')
-                logging.warning("[!] Received mobile-remote-call with method '{}' of service '{}'".format(
+                log.warning("[!] Received mobile-remote-call with method '{}' of service '{}'".format(
                                 mobile_remote_call['method'], mobile_remote_call['service']))
             elif data.find('images'):
                 # images


### PR DESCRIPTION
I was trying to run multiple bots at once, and encountered some issues:

- The root logger is configured in the api, file and stream handlers are added every time the API is initialized. This PR uses a separate logger which keeps only one file / stream handler.
- Different accounts with the same device id / android id can't be logged in at the same time, this allows for an optional override.
- The intermediary captchas can now be solved