### PR TITLE
Fix UUID bug, log instead of NotImplementedError

### DIFF
--- a/kik_unofficial/client.py
+++ b/kik_unofficial/client.py
@@ -309,7 +309,10 @@ class KikClient:
         if 'xmlns' in xmpp_message.attrs:
             self._handle_xmlns(xmpp_message['xmlns'], xmpp_message)
         elif xmpp_message['type'] == 'receipt':
-            self.callback.on_group_receipts_received(chatting.IncomingGroupReceiptsEvent(xmpp_message))
+            if xmpp_message.g:
+                self.callback.on_group_receipts_received(chatting.IncomingGroupReceiptsEvent(xmpp_message))
+            else:
+                self.xml_namespace_handlers['jabber:client'].handle(xmpp_message)
         else:
             # iPads send messages without xmlns, try to handle it as jabber:client
             self.xml_namespace_handlers['jabber:client'].handle(xmpp_message)

--- a/kik_unofficial/utilities/cryptographics.py
+++ b/kik_unofficial/utilities/cryptographics.py
@@ -65,6 +65,8 @@ class CryptographicUtils:
         # a manually converted code from classes2/kik/core/net/f.java
         # used to make UUIDs for messages
         random_uuid = uuid.uuid4().int
+        while random_uuid.bit_length() < 121:
+            random_uuid = uuid.uuid4().int
 
         bytes_array = random_uuid.to_bytes((random_uuid.bit_length() + 7) // 8, 'big')
         most_significant_bits = int.from_bytes(bytes_array[:8], byteorder='big')

--- a/kik_unofficial/xmlns_handlers.py
+++ b/kik_unofficial/xmlns_handlers.py
@@ -106,9 +106,9 @@ class MessageHandler(XmlnsHandler):
             elif data.find('sysmsg'):
                 self.callback.on_group_sysmsg_received(IncomingGroupSysmsg(data))
             else:
-                raise NotImplementedError
+                log.debug("[-] Received unknown groupchat message. contents: {}".format(str(data)))
         else:
-            raise NotImplementedError
+            log.debug("[-] Received unknown message type. contents: {}".format(str(data)))
 
 
 class GroupMessageHandler(XmlnsHandler):
@@ -127,7 +127,7 @@ class GroupMessageHandler(XmlnsHandler):
                 self.callback.on_image_received(IncomingImageMessage(data))
 
         else:
-            raise NotImplementedError
+            log.debug("[-] Received unknown group message. contents: {}".format(str(data)))
 
 
 class FriendMessageHandler(XmlnsHandler):


### PR DESCRIPTION
Fixes a bug in UUID generation causing the following message:
```ValueError: badly formed hexadecimal UUID string```

Maybe there's a better way, but it doesn't occur very frequently so performance impact should be low.

I replaced some other raised NotImplementedErrors with logging too. After this PR the client doesn't throw exceptions for me anymore, which is nice.

The change in client.py was added because I received a chat receipt as groupchat receipt.