### PR TITLE
Don't use f-strings for python36 compat

### DIFF
--- a/kik_unofficial/utilities/parsing_utilities.py
+++ b/kik_unofficial/utilities/parsing_utilities.py
@@ -23,7 +23,7 @@ class ParsingUtilities:
 
     @staticmethod
     def fix_base64_padding(data):
-        return f"{data}{'=' * (4-(len(data)) % 4)}"
+        return data + '=' * (-len(data) % 4)
 
     @staticmethod
     def byte_to_signed_int(byte):


### PR DESCRIPTION
As we currently support Python 3.6 and f-strings are only added in Python 3.7, refrain from using those.