### PR TITLE
Updated the xmlns key to kik's newly returned 'xmlns:'

### DIFF
--- a/kik_unofficial/client.py
+++ b/kik_unofficial/client.py
@@ -525,7 +525,7 @@ class KikClient:
 
         :param iq_element: The iq XML element we just received from kik.
         """
-        self._handle_xmlns(iq_element.query['xmlns'], iq_element)
+        self._handle_xmlns(iq_element.query['xmlns:'], iq_element)
 
     def _handle_xmpp_message(self, xmpp_message: BeautifulSoup):
         """


### PR DESCRIPTION
Kik has recently changed the iq request name space attribute from 'xmlns' to 'xmlns:' and BS4 isn't handling the colon tag. This rectifies it.