### PR TITLE
Adding gif support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Currently Supported Operations:
 - Receive media content: camera, gallery, stickers
 - Add a kik user as a friend
 - Send images
+- Send gifs (add tenor API key to datatypes/xmpp/chatting.py getGIFData() function)
 
-Sending videos or recordings is not suported yet.
+Sending videos or recordings is not supported yet.
 
 ## Troubleshooting
-If you are on Windows and you are unable to install the lxml pacakge, use the binary installers from PyPi [here](https://pypi.python.org/pypi/lxml/3.3.5#downloads).
+If you are on Windows and you are unable to install the lxml package, use the binary installers from PyPi [here](https://pypi.python.org/pypi/lxml/3.3.5#downloads).

--- a/kik_unofficial/client.py
+++ b/kik_unofficial/client.py
@@ -604,6 +604,21 @@ class KikClient:
 
         logging.getLogger('asyncio').setLevel(logging.WARNING)
 
+    def send_gif_image(self, peer_jid: str, search_term):
+        """
+        Sends a gif chat message to another person or a group with the given JID/username.
+        :param peer_jid: The Jabber ID for which to send the message (looks like username_ejs@talk.kik.com
+        :param search_term: Search term for the gif
+        """
+        if self.is_group_jid(peer_jid):
+            log.info("[+] Sending chat gif to group '{}'...".format(peer_jid))
+            return self._send_xmpp_element(chatting.OutgoingGIFMessage(peer_jid, search_term, True))
+        else:
+            log.info("[+] Sending chat gif to user '{}'...".format(peer_jid))
+            return self._send_xmpp_element(chatting.OutgoingGIFMessage(peer_jid, search_term, False))
+
+
+
     @staticmethod
     def is_group_jid(jid):
         if '@talk.kik.com' in jid:


### PR DESCRIPTION
With this PR and fork the API is able to send gifs to users or groups with:

client.send_gif_image(jid, "search term for gif", group_bool)

You must first add your own tenor API key to datatypes/xmpp/chatting.py (variable named "apikey")