### PR TITLE
don't ignore status and sysmsg in group msg handler

### DIFF
--- a/kik_unofficial/xmlns_handlers.py
+++ b/kik_unofficial/xmlns_handlers.py
@@ -99,6 +99,10 @@ class GroupXMPPMessageHandler(XmppHandler):
             self.callback.on_group_message_received(IncomingGroupChatMessage(data))
         elif data.find('is-typing'):
             self.callback.on_group_is_typing_event_received(IncomingGroupIsTypingEvent(data))
+        elif data.find('status'):
+            self.callback.on_group_status_received(IncomingGroupStatus(data))
+        elif data.find('sysmsg'):
+            self.callback.on_group_sysmsg_received(IncomingGroupSysmsg(data))
         elif data.content and 'app-id' in data.content.attrs:
             app_id = data.content['app-id']
             if app_id == 'com.kik.ext.stickers':


### PR DESCRIPTION
When I receive "status" or "sysmsg" messages, they are not forwarded to the callback object because each message of type "groupchat" is processed by ```GroupXMPPMessageHandler``` if its node contains an "xmlns" attribute. Compare the method ```_handle_kik_event```. At least on my setup, many, if not all, received messages do contain that "xmlns" attribute. For example:

* other user joined
* other user left
* other user was invited by yet another user
* other user was removed by yet another user

I did not really understand the iPad-specific edge case. Is this outdated by 9ea8795063a353a212b? That commit removed the namespace check for "kik:groups".

Anyway, ```GroupXMPPMessageHandler``` and ```XMPPMessageHandler``` already have redundant code for ```IncomingGroupChatMessage``` and ```IncomingGroupIsTyping```. So I thought that just copying the other two if branches might be fine in the context of this PR.

I don't know if there are more, equivalent bugs.