### PR TITLE
remove custom logging configuration

### DIFF
--- a/examples/echo_bot.py
+++ b/examples/echo_bot.py
@@ -3,6 +3,8 @@ A Kik bot that just logs every event that it gets (new message, message read, et
 and echos back whatever chat messages it receives.
 """
 
+import logging
+
 import kik_unofficial.datatypes.xmpp.chatting as chatting
 from kik_unofficial.client import KikClient
 from kik_unofficial.callbacks import KikClientCallback
@@ -16,6 +18,7 @@ password = 'your_kik_password'
 
 
 def main():
+    logging.basicConfig(format=KikClient.log_format(), level=logging.INFO)
     bot = EchoBot()
 
 

--- a/examples/interactive_client.py
+++ b/examples/interactive_client.py
@@ -76,5 +76,6 @@ def chat():
 
 
 if __name__ == '__main__':
+    logging.basicConfig(format=KikClient.log_format(), level=logging.DEBUG)
     callback = InteractiveChatClient()
-    client = KikClient(callback=callback, kik_username=username, kik_password=password, log_level=logging.DEBUG)
+    client = KikClient(callback=callback, kik_username=username, kik_password=password)

--- a/examples/register_client.py
+++ b/examples/register_client.py
@@ -38,5 +38,6 @@ if __name__ == '__main__':
     last = input('Last name: ')
     email = input('Email: ')
     birthday = input('Birthday: (like 01-01-1990): ')
-    client = KikClient(callback=RegisterClient(), log_level=logging.DEBUG)
+    logging.basicConfig(format=KikClient.log_format(), level=logging.DEBUG)
+    client = KikClient(callback=RegisterClient())
     client.register(email, username, password, first, last, birthday)

--- a/kik_unofficial/client.py
+++ b/kik_unofficial/client.py
@@ -25,14 +25,13 @@ from kik_unofficial.http import profile_pictures, content
 HOST, PORT = "talk1110an.kik.com", 5223
 log = logging.getLogger('kik_unofficial')
 
-
 class KikClient:
     """
     The main kik class with which you're managing a kik connection and sending commands
     """
 
     def __init__(self, callback: callbacks.KikClientCallback, kik_username, kik_password,
-                 kik_node=None, log_level=logging.INFO, device_id_override=None, android_id_override=None):
+                 kik_node=None, device_id_override=None, android_id_override=None):
         """
         Initializes a connection to Kik servers.
         If you want to automatically login too, use the username and password parameters.
@@ -44,10 +43,7 @@ class KikClient:
         :param kik_password: the kik password to log in with.
         :param kik_node: the username plus 3 letters after the "_" and before the "@" in the JID. If you know it,
                          authentication will happen faster and without a login. otherwise supply None.
-        :param log_level: logging level.
         """
-        self._set_up_logging(log_level)
-
         self.username = kik_username
         self.password = kik_password
         self.kik_node = kik_node
@@ -664,25 +660,9 @@ class KikClient:
 
         return None
 
-    def _set_up_logging(self, log_level):
-        log_formatter = logging.Formatter('[%(asctime)-15s] %(levelname)-6s (thread %(threadName)-10s): %(message)s')
-        root_logger = logging.getLogger()
-        root_logger.setLevel(logging.DEBUG)
-
-        kik_logger = logging.getLogger('kik_unofficial')
-
-        if len(kik_logger.handlers) == 0:
-            file_handler = logging.FileHandler("kik-debug.log")
-            file_handler.setFormatter(log_formatter)
-            file_handler.setLevel(logging.DEBUG)
-            kik_logger.addHandler(file_handler)
-
-            console_handler = logging.StreamHandler(sys.stdout)
-            console_handler.setLevel(log_level)
-            console_handler.setFormatter(log_formatter)
-            kik_logger.addHandler(console_handler)
-
-        logging.getLogger('asyncio').setLevel(logging.WARNING)
+    @staticmethod
+    def log_format():
+        return '[%(asctime)-15s] %(levelname)-6s (thread %(threadName)-10s): %(message)s'
 
     @staticmethod
     def is_group_jid(jid):


### PR DESCRIPTION
See the commit message for the rationale.

If you want to keep the two handlers etc., I suggest that we move that   stuff to a public method ```set_up_dev_logging``` or something like that. Either way, in my opinion, not touching the logging configuration should at least be the default behavior.