### PR TITLE
Allow direct usage of example scripts

### DIFF
--- a/examples/echo_bot.py
+++ b/examples/echo_bot.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 A Kik bot that just logs every event that it gets (new message, message read, etc.),
 and echos back whatever chat messages it receives.

--- a/examples/echo_bot.py
+++ b/examples/echo_bot.py
@@ -4,6 +4,7 @@ and echos back whatever chat messages it receives.
 """
 
 import logging
+import sys
 
 import kik_unofficial.datatypes.xmpp.chatting as chatting
 from kik_unofficial.client import KikClient
@@ -13,8 +14,8 @@ from kik_unofficial.datatypes.xmpp.roster import FetchRosterResponse, PeersInfoR
 from kik_unofficial.datatypes.xmpp.sign_up import RegisterResponse, UsernameUniquenessResponse
 from kik_unofficial.datatypes.xmpp.login import LoginResponse, ConnectionFailedResponse
 
-username = 'your_kik_username'
-password = 'your_kik_password'
+username = sys.argv[1]
+password = sys.argv[2] if len(sys.argv) > 2 else input('Password: ')
 
 
 def main():

--- a/examples/interactive_client.py
+++ b/examples/interactive_client.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import time
 import threading
 
@@ -8,8 +9,8 @@ from kik_unofficial.datatypes.xmpp.chatting import IncomingChatMessage, Incoming
 from kik_unofficial.datatypes.xmpp.roster import FetchRosterResponse
 from kik_unofficial.datatypes.xmpp.login import ConnectionFailedResponse
 
-username = 'your_kik_username'
-password = 'your_kik_password'
+username = sys.argv[1]
+password = sys.argv[2] if len(sys.argv) > 2 else input('Password: ')
 
 friends = {}
 

--- a/examples/interactive_client.py
+++ b/examples/interactive_client.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import logging
 import sys
 import time

--- a/examples/register_client.py
+++ b/examples/register_client.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import logging
 

--- a/examples/register_client.py
+++ b/examples/register_client.py
@@ -39,5 +39,6 @@ if __name__ == '__main__':
     email = input('Email: ')
     birthday = input('Birthday: (like 01-01-1990): ')
     logging.basicConfig(format=KikClient.log_format(), level=logging.DEBUG)
-    client = KikClient(callback=RegisterClient())
+    client = KikClient(callback=RegisterClient(),
+            kik_username=None, kik_password=None)
     client.register(email, username, password, first, last, birthday)

--- a/examples/register_client.py
+++ b/examples/register_client.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 
 from kik_unofficial.client import KikClient
@@ -23,7 +24,8 @@ class RegisterClient(KikClientCallback):
         if "captcha_url" in dir(response):
             print(response.captcha_url)
             result = input("Captcha result:")
-            client.register(email, username, password, first, last, birthday, result)
+            client.register(args.email, args.username, args.password,
+                    args.firstname, args.lastname, args.birthday, result)
         else:
             print("Unable to register! error information:\r\n{}".format(response))
 
@@ -32,13 +34,19 @@ class RegisterClient(KikClientCallback):
 
 
 if __name__ == '__main__':
-    username = input('Username: ')
-    password = input('Password: ')
-    first = input('First name: ')
-    last = input('Last name: ')
-    email = input('Email: ')
-    birthday = input('Birthday: (like 01-01-1990): ')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('username')
+    parser.add_argument('email')
+    parser.add_argument('-p', '--password')
+    parser.add_argument('--firstname', default='Not A')
+    parser.add_argument('--lastname', default='Human')
+    parser.add_argument('--birthday', default='01-01-1990')
+    args = parser.parse_args()
+    if args.password is None:
+        args.password = input('Password: ')
+
     logging.basicConfig(format=KikClient.log_format(), level=logging.DEBUG)
     client = KikClient(callback=RegisterClient(),
             kik_username=None, kik_password=None)
-    client.register(email, username, password, first, last, birthday)
+    client.register(args.email, args.username, args.password,
+            args.firstname, args.lastname, args.birthday)


### PR DESCRIPTION
Even in their original form, these scripts can be quite helpful. In my opinion, we should make them directly usable. Also, this would make them more maintainable since changing the hard-coded login data for test runs wouldn't be necessary anymore.

See also: [details on Python shebangs](https://docs.python.org/3/using/windows.html#shebang-lines)