### PR TITLE
fix send_chat_message not being able to send to group

### DIFF
--- a/kik_unofficial/client.py
+++ b/kik_unofficial/client.py
@@ -883,7 +883,10 @@ class KikClient:
         if jid_utilities.is_pm_jid(username_or_jid):
             # this is already a JID.
             return username_or_jid
-
+        elif jid_utilities.is_group_jid(username_or_jid):
+            # this is already a group JID.
+            return username_or_jid
+        
         username = username_or_jid
 
         # first search if we already have it


### PR DESCRIPTION
Without checking, if the provided JID is a valid group JID, the bot crashes because its trying to request a JID from a JID...