### PR TITLE
Add new version info, bad version handling, deprecate registration

### DIFF
--- a/kik_unofficial/datatypes/xmpp/login.py
+++ b/kik_unofficial/datatypes/xmpp/login.py
@@ -192,8 +192,16 @@ class ConnectionFailedResponse:
     def __init__(self, data: BeautifulSoup):
         """True if the password / device ID pair was invalidated (auth rejected)"""
         self.is_auth_revoked = is_tag_present(data, "noauth")
-        """the error message received. Will be an empty string if is_auth_revoked = False"""
-        self.message = data.noauth.msg.text if is_tag_present(data, "noauth") else ""
+
+        """True if the version is rejected due to being out of date."""
+        self.is_bad_version = is_tag_present(data, "badver")
+
+        if self.is_auth_revoked:
+            self.message = data.noauth.msg.text
+        elif self.is_bad_version:
+            self.message = data.badver.msg.text
+        else:
+            self.message = ''
 
         """True if a backoff was requested by Kik's server"""
         self.is_backoff = is_tag_present(data, "wait")

--- a/kik_unofficial/device_configuration.py
+++ b/kik_unofficial/device_configuration.py
@@ -3,6 +3,7 @@ Here we put all the device configuration that we emulate.
 """
 
 # possible kik versions to emulate
+# note that downgrading causes authentication to be lost
 kik_version_11_info = {"kik_version": "11.1.1.12218", "classes_dex_sha1_digest": "aCDhFLsmALSyhwi007tvowZkUd0="}
 kik_version_13_info = {"kik_version": "13.4.0.9614", "classes_dex_sha1_digest": "ETo70PFW30/jeFMKKY+CNanX2Fg="}
 kik_version_14_info = {"kik_version": "14.0.0.11130", "classes_dex_sha1_digest": "9nPRnohIOTbby7wU1+IVDqDmQiQ="}
@@ -11,5 +12,6 @@ kik_version_15_21_info = {"kik_version": "15.21.0.22201", "classes_dex_sha1_dige
 kik_version_15_49_info = {"kik_version": "15.49.0.27501", "classes_dex_sha1_digest": "5o61frOsakJJ2iCYafCoKHtyu7w="}
 kik_version_15_57_info = {"kik_version": "15.57.2.29235", "classes_dex_sha1_digest": "hA77Y2jUTVbpHRB9LosnnunQ1PY="}
 kik_version_15_60_info = {"kik_version": "15.60.1.29587", "classes_dex_sha1_digest": "FXxvP2QjSj+sXp+G1MqDdxz8Z51YjtqzFOQ7wlex0VM="}
+kik_version_17_0_info = {"kik_version": "17.0.0.31357", "classes_dex_sha1_digest": "Rm2No4v27p+pIF4DVwXJvXVvdds="}
 
-kik_version_info = kik_version_15_60_info  # a kik version that's not updated will cause a captcha on login
+kik_version_info = kik_version_17_0_info


### PR DESCRIPTION
Client can now authenticate with an established session again (device_id, recommended) or login via username/password.

Signup (register) is now a no-op and logs an error as Kik has completely redesigned the process to introduce new third-party security mechanisms and has blocked the current XMPP method.

Closes #261 